### PR TITLE
Improve compatibility with GemStone 64

### DIFF
--- a/source/BaselineOfJRPC/BaselineOfJRPC.class.st
+++ b/source/BaselineOfJRPC/BaselineOfJRPC.class.st
@@ -35,6 +35,14 @@ BaselineOfJRPC >> setUpClientDeploymentPackages: spec [
 ]
 
 { #category : #baselines }
+BaselineOfJRPC >> setUpDependencies: spec [
+
+	spec
+		baseline: 'Buoy' with: [ spec repository: 'github://ba-st/Buoy:v7' ];
+		project: 'Buoy-Deployment' copyFrom: 'Buoy' with: [ spec loads: 'Deployment' ]
+]
+
+{ #category : #baselines }
 BaselineOfJRPC >> setUpPackages: spec [
 
 	spec package: 'JRPC-Common'.
@@ -63,7 +71,8 @@ BaselineOfJRPC >> setUpPackages: spec [
 BaselineOfJRPC >> setUpServerDeploymentPackages: spec [
 
 	spec
-		package: 'JRPC-Server-Core' with: [ spec requires: #('JRPC-Extensions' 'JRPC-STON-Extensions') ];
+		package: 'JRPC-Server-Core'
+		with: [ spec requires: #( 'JRPC-Extensions' 'JRPC-STON-Extensions' 'Buoy-Deployment' ) ];
 		group: 'Server-Deployment' with: 'JRPC-Server-Core'.
 
 	spec

--- a/source/BaselineOfJRPC/BaselineOfJRPC.class.st
+++ b/source/BaselineOfJRPC/BaselineOfJRPC.class.st
@@ -9,7 +9,9 @@ BaselineOfJRPC >> baseline: spec [
 
 	<baseline>
 	spec for: #pharo do: [
-		self setUpPackages: spec.
+		self
+			setUpDependencies: spec;
+			setUpPackages: spec.
 		spec
 			group: 'CI' with: 'Tests';
 			group: 'Development' with: 'Tests'

--- a/source/JRPC-Common/JRPCError.class.st
+++ b/source/JRPC-Common/JRPCError.class.st
@@ -20,8 +20,3 @@ JRPCError >> asJRPCResponseWithId: anInteger [
 	 To be overrided by subclasses."
 	^ self subclassResponsibility
 ]
-
-{ #category : #testing }
-JRPCError >> isIncorrectJSON [
-	^ false
-]

--- a/source/JRPC-Extensions/Error.extension.st
+++ b/source/JRPC-Extensions/Error.extension.st
@@ -24,3 +24,9 @@ Error >> asJRPCResponseWithId: anInteger [
 		data: self asJRPCJSON.
 	^ response
 ]
+
+{ #category : #'*JRPC-Extensions' }
+Error >> isIncorrectJSON [
+
+	^ false
+]

--- a/source/JRPC-Server-Core/JRPCMessageProcessor.class.st
+++ b/source/JRPC-Server-Core/JRPCMessageProcessor.class.st
@@ -53,13 +53,12 @@ JRPCMessageProcessor >> handleErrorsDuring: aBlock for: aJRPCRequestObject [
 
 	^ self debugMode
 		  ifTrue: aBlock
-		  ifFalse: [ 
-			  aBlock
-				  on: Error
-				  do: [ :jrpcError | 
-					  errorHandlers do: [ :handler | handler cull: jrpcError ].
-					  jrpcError return:
-						  (aJRPCRequestObject convertErrorToResponse: jrpcError) ] ]
+		  ifFalse: [
+			  aBlock on: Error except: Exit do: [ :jrpcError |
+				  errorHandlers do: [ :handler | handler cull: jrpcError ].
+				  jrpcError return: ( aJRPCRequestObject convertErrorToResponse: jrpcError )
+				  ]
+			  ]
 ]
 
 { #category : #'handling - jrpc' }
@@ -116,13 +115,11 @@ JRPCMessageProcessor >> handleJSON: aJSONString [
 
 	jrpcResponse := [
 	                ( parser parseSupposedJRPCMessageObjectFromString: aJSONString forClient: false )
-		                beHandledBy: self ]
-		                on: Error
-		                do: [ :error |
-			                self debugMode
-				                ifTrue: [ error pass ]
-				                ifFalse: [ error return: error asJRPCResponse ]
-			                ].
+		                beHandledBy: self ] on: Error except: Exit do: [ :error |
+		                self debugMode
+			                ifTrue: [ error pass ]
+			                ifFalse: [ error return: error asJRPCResponse ]
+		                ].
 
 	^ jrpcResponse beConvertedBy: self
 ]


### PR DESCRIPTION
Exclude Exit from handlers or Error because inGS64 it is a subclass of Error.

This change is innocuous in Pharo.